### PR TITLE
Adds psutil to driver container's requirements.txt

### DIFF
--- a/driver/requirements.txt
+++ b/driver/requirements.txt
@@ -1,3 +1,4 @@
+psutil
 gevent
 requests
 websocket


### PR DESCRIPTION
When trying to start the `driver` container, it would immediately exit with an error in `monkey.py`. I traced this back to a missing Python module - `psutil`. This change adds the `psutil` module to the `requirements.txt` for the `driver` image.